### PR TITLE
Alarm Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ shows the expected time drift (assuming 2ppm error) since the given time. The re
 ## ALARM 1/2
 The DS32321 has two alarm slots, and these can be enabled/disabled independently.
 They differ only in that Alarm 1 has resolution to the second, Alarm 2 has
-resolution to the minute.  Internally, it functions similar to other time
+resolution only to the minute.  Internally, it functions similar to other time
 functions: of the 4 properties (hour, minute, second, day) each can be set as
 'match' or 'ignore'.  This allows some interesting alarm types, including
 'every minute at :30 seconds' or 'every day'.
@@ -130,10 +130,18 @@ The code has several functions supporting alarms:
 - `is-alarm-triggered`: returns true when the specified alarm has tripped.
 - `clear-alarm`: clears a raised alarm.  (Will not clear by itself.)
 
-The Alarmspec object can be used to describe an alarm time.  It has helpers to
-set common configurations.  See the [examples](./examples/).  Printing it will
-show the outcome.
+The Alarmspec object is used to describe an alarm time, and store it in a format
+that the DS3231 understands.  It has helpers to set common configurations.
+See the [examples](./examples/).  Printing it will show the outcome of setting
+and enabling the alarm.  If a `AlarmSpec` is configured to the second, but
+stored in slot 2, the seconds allocation is dropped but other data still written.
 
+> [!WARNING]
+> Out of the box, corrupt/nonsensical data can be in these registers.  This is
+> noncritical in that first, they are not enabled by default.  Second, if they
+> are enabled, the alarm will trigger when the selected digits from the time
+> match.  This would mean that if the data would say 33:00 o'clock, the
+> alarm will simply never trigger.
 
 ## Aging correction
 

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ All the above are only useful, if you know the wanted accuracy. Some hints:
   the DS3231 is already extremely accurate.
 
 - For projects expecting to be mostly without wifi, the aging correction can be
-  useful, but a 1 minute error per year can still be insignificant 
+  useful, but a 1 minute error per year can still be insignificant
   (irrigation timer comes to mind). See below on how to calculate the aging offset
-  
+
 - For projects really isolated (from the internet) and still requiring high time
   precision, a GNSS module can be a solution (you have to solve other problems of
   course). For Toit there are GNSS drivers, but I have not tested them.
@@ -112,7 +112,28 @@ returns the temperature in °C as a float. Internally is updated every about 1 m
 shows the expected time drift (assuming 2ppm error) since the given time. The real drift is usually smaller. You can set the ppm error.
 
 ## ALARM 1/2
-Not implemented at the moment.
+The DS32321 has two alarm slots, and these can be enabled/disabled independently.
+They differ only in that Alarm 1 has resolution to the second, Alarm 2 has
+resolution to the minute.  Internally, it functions similar to other time
+functions: of the 4 properties (hour, minute, second, day) each can be set as
+'match' or 'ignore'.  This allows some interesting alarm types, including
+'every minute at :30 seconds' or 'every day'.
+
+The code has several functions supporting alarms:
+- `get-alarm`: Returns an `AlarmSpec` object, used to store/configure the alarm
+  moment description.
+- `set-alarm`: Takes an `AlarmSpec` and sets either of the alarm slots to the
+  alarm time.
+- `set-sqw-as-interrupt`: takes a boolean to either set or unset the SQW pin as
+  a GPIO pin alarm interrupt.
+- `enable-alarm`: activates or deactivates either alarm slot.
+- `is-alarm-triggered`: returns true when the specified alarm has tripped.
+- `clear-alarm`: clears a raised alarm.  (Will not clear by itself.)
+
+The Alarmspec object can be used to describe an alarm time.  It has helpers to
+set common configurations.  See the [examples](./examples/).  Printing it will
+show the outcome.
+
 
 ## Aging correction
 

--- a/README.md
+++ b/README.md
@@ -129,11 +129,8 @@ The code has several functions supporting alarms:
 - `is-alarm-triggered`: returns true when the specified alarm has tripped.
 - `clear-alarm`: clears a raised alarm.  (Will not clear by itself.)
 
-The `AlarmSpec` object is used to describe an alarm time, and store it in a format
-that the DS3231 understands.  It has helpers to set common configurations.
-See the [examples](./examples/).  Printing it will show the outcome of setting
-and enabling the alarm.  If a `AlarmSpec` is configured to the second, but
-stored in slot 2, the seconds allocation is dropped but other data still written.
+If a `AlarmSpec` is configured to the second, but stored in slot 2, the seconds
+allocation is dropped but other data still written.
 
 > [!WARNING]
 > Out of the box, corrupt/nonsensical data can be in these registers.  This is
@@ -141,6 +138,26 @@ stored in slot 2, the seconds allocation is dropped but other data still written
 > are enabled, the alarm will trigger when the selected digits from the time
 > match.  This would mean that if the data would say 33:00 o'clock, the
 > time would never match, and therefore, the alarm will simply never trigger.
+
+### Using AlarmSpec
+The `AlarmSpec` object is used to describe an alarm time, and store it in a
+format that the DS3231 understands.  The object is designed to be immutable,
+however it does have a `.with` function to create a new object by modifying an
+existing one.  It has helpers to set common configurations. See the
+[examples](./examples/).
+
+
+Printing it will show the outcome of setting and enabling the alarm.  In this
+example, create an 'every-minute' alarm - would raise every time the seconds
+get to '30':
+```Toit
+minutely := AlarmSpec.every-minute --seconds=30
+print "Hourly alarm is: $minutely ($(minutely.stringify --debug))"
+
+// Set alarm in the registers:
+rtc.set-alarm 1 minutely
+print "Alarm 1 now set to: $minutely."
+```
 
 ## Aging correction
 

--- a/README.md
+++ b/README.md
@@ -120,8 +120,7 @@ functions: of the 4 properties (hour, minute, second, day) each can be set as
 'every minute at :30 seconds' or 'every day'.
 
 The code has several functions supporting alarms:
-- `get-alarm`: Returns an `AlarmSpec` object, used to store/configure the alarm
-  moment description.
+- `get-alarm`: Returns an `AlarmSpec` object containing the alarm time/moment.
 - `set-alarm`: Takes an `AlarmSpec` and sets either of the alarm slots to the
   alarm time.
 - `set-sqw-as-interrupt`: takes a boolean to either set or unset the SQW pin as
@@ -130,7 +129,7 @@ The code has several functions supporting alarms:
 - `is-alarm-triggered`: returns true when the specified alarm has tripped.
 - `clear-alarm`: clears a raised alarm.  (Will not clear by itself.)
 
-The Alarmspec object is used to describe an alarm time, and store it in a format
+The `AlarmSpec` object is used to describe an alarm time, and store it in a format
 that the DS3231 understands.  It has helpers to set common configurations.
 See the [examples](./examples/).  Printing it will show the outcome of setting
 and enabling the alarm.  If a `AlarmSpec` is configured to the second, but

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ stored in slot 2, the seconds allocation is dropped but other data still written
 > noncritical in that first, they are not enabled by default.  Second, if they
 > are enabled, the alarm will trigger when the selected digits from the time
 > match.  This would mean that if the data would say 33:00 o'clock, the
-> alarm will simply never trigger.
+> time would never match, and therefore, the alarm will simply never trigger.
 
 ## Aging correction
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ hard job. At the moment the library has limited testing and bugs are expected.
 Any help on inmpoving the driver is welcome.
 
 ## Installing + documentation
-See [ds3231 at Toid package registry](https://pkg.toit.io/search?query=ds3231)
+See [ds3231 at Toit package registry](https://pkg.toit.io/search?query=ds3231)
 
 ## Connection
 You need 4 pins:

--- a/examples/alarms-read.toit
+++ b/examples/alarms-read.toit
@@ -1,0 +1,22 @@
+import ds3231 show Ds3231
+
+/*
+Scenario:
+
+We have an RTC and we wish to see what alarms are programmed with it.
+
+// rtc ::= Ds3231 --scl=7 --sda=6 --vcc=10 --gnd=3 /* esp32-c3 core with GPIO as vcc and gnd */
+// rtc := Ds3231 --sda=25 --scl=26 --vcc=33 --gnd=32 /* Lolin32 lite */
+// rtc := Ds3231 --sda=33 --scl=32 --vcc=25 --gnd=26 /* ESP32 Devkit all versions */
+// rtc := Ds3231 --sda=35 --scl=36 --vcc=37 --gnd=38 /* S3 devkitC abudance of pins here */
+
+*/
+
+rtc ::= Ds3231 --scl=20 --sda=19 /* esp32-c6 DFrobot Beetle */
+
+main:
+  alarm1 := rtc.get-alarm 1
+  alarm2 := rtc.get-alarm 2
+
+  print "Alarm 1: $alarm1"
+  print "Alarm 2: $alarm2"

--- a/examples/alarms-set.toit
+++ b/examples/alarms-set.toit
@@ -1,0 +1,41 @@
+import ds3231 show *
+
+/*
+Scenario:
+
+We have an RTC and we wish to program an alarm.
+
+// rtc ::= Ds3231 --scl=7 --sda=6 --vcc=10 --gnd=3 /* esp32-c3 core with GPIO as vcc and gnd */
+// rtc := Ds3231 --sda=25 --scl=26 --vcc=33 --gnd=32 /* Lolin32 lite */
+// rtc := Ds3231 --sda=33 --scl=32 --vcc=25 --gnd=26 /* ESP32 Devkit all versions */
+// rtc := Ds3231 --sda=35 --scl=36 --vcc=37 --gnd=38 /* S3 devkitC abudance of pins here */
+
+*/
+
+rtc ::= Ds3231 --scl=20 --sda=19 /* esp32-c6 DFrobot Beetle */
+
+main:
+  alarm1 := rtc.get-alarm 1
+  alarm2 := rtc.get-alarm 2
+  print "Alarm 1 was: $alarm1 ($(alarm1.stringify --debug))"
+  print "Alarm 2 was: $alarm2 ($(alarm2.stringify --debug))"
+
+  // Create blank alarm object - essentially every second:
+  blank := AlarmSpec
+  print "Blank alarm is: $blank ($(blank.stringify --debug))"
+
+  // Create hourly alarm object - every time the minute gets to '00':
+  hourly := AlarmSpec.every-hour --minute=00
+  print "Hourly alarm is: $hourly ($(hourly.stringify --debug))"
+
+  // Create daily alarm object - at 12:00 every day:
+  daily := AlarmSpec.every-day --hour=12 --minute=00
+  print "Daily alarm is: $daily ($(daily.stringify --debug))"
+
+  rtc.set-alarm 1 blank
+  alarm1 = rtc.get-alarm 1
+  print "Alarm 1 is now: $alarm1"
+
+
+  print "Alarm 1: $alarm1"
+  print "Alarm 2: $alarm2"

--- a/examples/alarms-set.toit
+++ b/examples/alarms-set.toit
@@ -15,14 +15,17 @@ We have an RTC and we wish to program an alarm.
 rtc ::= Ds3231 --scl=20 --sda=19 /* esp32-c6 DFrobot Beetle */
 
 main:
-  alarm1 := rtc.get-alarm 1
-  alarm2 := rtc.get-alarm 2
-  print "Alarm 1 was: $alarm1 ($(alarm1.stringify --debug))"
-  print "Alarm 2 was: $alarm2 ($(alarm2.stringify --debug))"
+  print
+
+  // Show some ways of creating the alarms
 
   // Create blank alarm object - essentially every second:
   blank := AlarmSpec
   print "Blank alarm is: $blank ($(blank.stringify --debug))"
+
+  // Create hourly alarm object - every time the minute gets to '00':
+  minutely := AlarmSpec.every-minute --seconds=30
+  print "Hourly alarm is: $minutely ($(minutely.stringify --debug))"
 
   // Create hourly alarm object - every time the minute gets to '00':
   hourly := AlarmSpec.every-hour --minute=00
@@ -32,10 +35,17 @@ main:
   daily := AlarmSpec.every-day --hour=12 --minute=00
   print "Daily alarm is: $daily ($(daily.stringify --debug))"
 
-  rtc.set-alarm 1 blank
-  alarm1 = rtc.get-alarm 1
-  print "Alarm 1 is now: $alarm1"
+  // Current configuration:
+  alarm1 := rtc.get-alarm 1
+  alarm2 := rtc.get-alarm 2
+  print "Alarm 1 is: $alarm1"
+  print "Alarm 2 is: $alarm2"
 
+  // Set both to blank:
+  rtc.set-alarm 1 minutely
+  rtc.set-alarm 2 blank
+  print "Alarm 1 now set to: $minutely and Alarm 2 now set to: $blank"
 
-  print "Alarm 1: $alarm1"
-  print "Alarm 2: $alarm2"
+  // Set SQW Pin to Interrupt output:
+  rtc.set-sqw-as-interrupt true
+

--- a/examples/alarms-test.toit
+++ b/examples/alarms-test.toit
@@ -1,0 +1,47 @@
+import ds3231 show *
+
+/*
+Scenario:
+
+We have an RTC and we wish to program an alarm.
+
+This method uses a task to watch the alarm trigger register.  Using a pin
+interrupt would be the more common method - in a separate example.
+
+// rtc ::= Ds3231 --scl=7 --sda=6 --vcc=10 --gnd=3 /* esp32-c3 core with GPIO as vcc and gnd */
+// rtc := Ds3231 --sda=25 --scl=26 --vcc=33 --gnd=32 /* Lolin32 lite */
+// rtc := Ds3231 --sda=33 --scl=32 --vcc=25 --gnd=26 /* ESP32 Devkit all versions */
+// rtc := Ds3231 --sda=35 --scl=36 --vcc=37 --gnd=38 /* S3 devkitC abudance of pins here */
+
+*/
+
+rtc ::= Ds3231 --scl=20 --sda=19 /* esp32-c6 DFrobot Beetle */
+
+main:
+  print
+
+  // Create every-minute alarm object - every time the seconds gets to '30':
+  minutely := AlarmSpec.every-minute --seconds=30
+  print "Hourly alarm is: $minutely ($(minutely.stringify --debug))"
+
+  // Set alarm in the registers:
+  rtc.set-alarm 1 minutely
+  print "Alarm 1 now set to: $minutely."
+
+  // Set SQW Pin to Interrupt (although we aren't using it in this example):
+  rtc.set-sqw-as-interrupt true
+
+  // Enable Alarm 1:
+  rtc.enable-alarm 1 true
+
+  // Start task to print a line when it sees the alarm register change.
+  task := ::
+    while true:
+      if rtc.is-alarm-triggered 1:
+        print " ** Alarm 1 triggered ** [$(Time.now.local)]"
+        rtc.clear-alarm 1
+      sleep --ms=1000
+
+  // Start task
+  task.call
+  return

--- a/examples/alarms-test.toit
+++ b/examples/alarms-test.toit
@@ -8,6 +8,9 @@ We have an RTC and we wish to program an alarm.
 This method uses a task to watch the alarm trigger register.  Using a pin
 interrupt would be the more common method - in a separate example.
 
+Note that the display shows the system time on the ESP32, not the time on
+the DS3231.
+
 // rtc ::= Ds3231 --scl=7 --sda=6 --vcc=10 --gnd=3 /* esp32-c3 core with GPIO as vcc and gnd */
 // rtc := Ds3231 --sda=25 --scl=26 --vcc=33 --gnd=32 /* Lolin32 lite */
 // rtc := Ds3231 --sda=33 --scl=32 --vcc=25 --gnd=26 /* ESP32 Devkit all versions */

--- a/src/ds3231.toit
+++ b/src/ds3231.toit
@@ -499,37 +499,3 @@ class AlarmSpec:
   */
   static monthly --day-of-month/int --hour/int=0 --minute/int=0 --second/int=0:
     return AlarmSpec --day-of-month=day-of-month --hour=hour --minute=minute --second=second
-
-  /* Graveyard:
-
-  seconds -> int:
-    return bcd72int payload_[SECONDS-BYTE_]
-
-  seconds n/int -> none:
-    assert: 0 <= n <= 59
-    payload_[SECONDS-BYTE_] = (payload_[SECONDS-BYTE_] & 0x80) | (int2bcd7 n)
-
-  set-seconds on/bool -> none:
-    payload_[SECONDS-BYTE_] = set-bit7 (not on) payload_[SECONDS-BYTE_]
-
-  minutes -> int:
-    return bcd72int payload_[MINUTES-BYTE_]
-
-  minutes n/int -> none:
-    assert: 0 <= n <= 59
-    payload_[MINUTES-BYTE_] = (payload_[MINUTES-BYTE_] & 0x80) | (int2bcd7 n)
-
-  set-minutes on/bool -> none:
-    payload_[MINUTES-BYTE_] = set-bit7 (not on) payload_[MINUTES-BYTE_]
-
-  is-minutes-set -> bool:
-    return not (is-bit7-set payload_[MINUTES-BYTE_])
-
-  static set-bit7 on/bool x/int -> int:
-    if on: return x | 0b1000_0000
-    return x & 0b0111_1111
-
-  static is-bit7-set x/int -> bool:
-    return (x & 0x80) != 0
-
-  */

--- a/src/ds3231.toit
+++ b/src/ds3231.toit
@@ -264,7 +264,6 @@ class Ds3231:
     else if frequency == 8000: set-sqw_ 0b000_110_00
     else: throw "INVALID_FREQUENCY"
 
-
   /** Disables the output on the sqw pin. */
   disable-sqw -> none :
     set-sqw_ 0b000_111_00
@@ -358,7 +357,7 @@ class Ds3231:
   /**
   Enables or disables either of the hardware alarms.
   */
-  enable-alarm_ alarm-num/int on/bool -> none:
+  enable-alarm alarm-num/int on/bool -> none:
     assert: 1 <= alarm-num <= 2
     mask := alarm-num == 1 ? ALARM-1-ENABLE_ : ALARM-2-ENABLE_
     control-reg := registers.read-u8 REG-CONTROL_
@@ -367,8 +366,10 @@ class Ds3231:
 
   /**
   Sets SQW pin as Interrupt for alarms.
+
+  Clears 
   */
-  set-int-sqw-as-interrupt on/bool -> none:
+  set-sqw-as-interrupt on/bool -> none:
     control-reg := registers.read-u8 REG-CONTROL_
     control-reg = on ? (control-reg | INTCN-BIT_) : (control-reg & ~INTCN-BIT_)
     registers.write-u8 REG-CONTROL_ control-reg
@@ -398,7 +399,7 @@ class Ds3231:
       if alarm.must-seconds-match:
         // Maybe this could send a log, dump the seconds byte, and save it anyway,
         // but maybe we'd risk weird outcomes like the alarm going every minute?
-        throw "Alarm 2 can not react to seconds set on an alarm."
+        print "Alarm 2 can not react to seconds set on an alarm."
       registers.write-bytes REG-ALARM-2-START_ alarm.to-byte-array[1..]
 
   /**
@@ -467,7 +468,7 @@ class AlarmSpec:
     if minute: assert: 0 <= minute <= 59
     if second: assert:  0 <= second <= 59
 
-    payload_ = DEFAULT-ARRAY_
+    payload_ = DEFAULT-ARRAY_.copy
 
     if second:
       payload_[SECONDS-BYTE_] = (payload_[SECONDS-BYTE_] & 0x80) | (encode-field_ second)

--- a/src/ds3231.toit
+++ b/src/ds3231.toit
@@ -380,8 +380,8 @@ class AlarmSpec:
       --second/int?=null
       --day/int?=null
       --weekly/bool?=null:
-    assert:
-      if weekly: 1 <= day <= 7
+    assert: if weekly != null:
+      if weekly == true: 1 <= day <= 7
       else: 1 <= day <= 31
     assert: if hour: 0 <= hour <= 23
     assert: if minute: 0 <= minute <= 59
@@ -402,9 +402,9 @@ class AlarmSpec:
 
     if weekly != null:
       if weekly:
-        payload_[DAY-BYTE_] = encode-day-field_ --day-of-month=day
-      else:
         payload_[DAY-BYTE_] = encode-day-field_ --day-of-week=day
+      else:
+        payload_[DAY-BYTE_] = encode-day-field_ --day-of-month=day
 
   /**
   Creates an object from register data.
@@ -437,13 +437,13 @@ class AlarmSpec:
     return bcd72int (payload_[DAY-BYTE_] & 0x3F)
 
   hour -> int:
-    return bcd72int payload_[HOURS-BYTE_]
+    return bcd72int (payload_[HOURS-BYTE_] & 0x7F)
 
   minute -> int:
-    return bcd72int payload_[MINUTES-BYTE_]
+    return bcd72int (payload_[MINUTES-BYTE_] & 0x7F)
 
   second -> int:
-    return bcd72int payload_[SECONDS-BYTE_]
+    return bcd72int (payload_[SECONDS-BYTE_] & 0x7F)
 
   /**
   Creates a copy of the object with supplied properties changed.

--- a/src/ds3231.toit
+++ b/src/ds3231.toit
@@ -366,8 +366,6 @@ class Ds3231:
 
   /**
   Sets SQW pin as Interrupt for alarms.
-
-  Clears 
   */
   set-sqw-as-interrupt on/bool -> none:
     control-reg := registers.read-u8 REG-CONTROL_

--- a/src/ds3231.toit
+++ b/src/ds3231.toit
@@ -421,6 +421,7 @@ class Ds3231:
     status-reg = status-reg & ~mask
     registers.write-u8 REG-STATUS_ status-reg
 
+
 class AlarmSpec:
   static SECONDS-BYTE_ ::= 0
   static MINUTES-BYTE_ ::= 1


### PR DESCRIPTION
I wanted to use the alarm capability on the RTC for a project, so I added it to your original code.  This PR only to offer this as part of your package instead of having two out in the wild.  Considering the capabilities of the ESP32, we could argue that such functionality is better served by coding the ESP32 directly, although perhaps not when we need the ESP32 in deep sleep etc.

Changes: 
- Extra `REG-*` statics and mask constants
- Extra functions all down the bottom
- Container class `AlarmSpec` created as a wrapper for the Alarm bytes
  - Is largely immutable, but does have a `.with` function to create a new object by modifying another
- README.md is modified

I've tried to follow your style and approach, if you want to modify things for better integration please be my guest.  I could probably spend more time on Toitdocs and comments too.  Either way this is a start, and I hope its ok!  Thanks!